### PR TITLE
Update configmap.yaml

### DIFF
--- a/charts/mongo-express/templates/tests/configmap.yaml
+++ b/charts/mongo-express/templates/tests/configmap.yaml
@@ -18,7 +18,7 @@ data:
 
 
     def test_service_connection():
-        url = "http://{{ include "mongo-express.fullname" . }}:{{ .Values.service.port }}/"
+        url = "http://{{ include "mongo-express.fullname" . }}:{{ .Values.service.port }}{{ default "/" .Values.siteBaseUrl }}"
 
         response = requests.get(url)
 


### PR DESCRIPTION
Fix for when .siteBaseUrl is not set to root path.  This allows test to pass rather then getting a 404.